### PR TITLE
Avoid globally changing thread behaviour

### DIFF
--- a/lib/ferrum.rb
+++ b/lib/ferrum.rb
@@ -3,9 +3,6 @@
 require "ferrum/browser"
 require "ferrum/node"
 
-Thread.abort_on_exception = true
-Thread.report_on_exception = true if Thread.respond_to?(:report_on_exception=)
-
 module Ferrum
   class Error               < StandardError; end
   class NoSuchWindowError   < Error; end

--- a/lib/ferrum/browser/client.rb
+++ b/lib/ferrum/browser/client.rb
@@ -16,6 +16,9 @@ module Ferrum
         @subscriber = Subscriber.new
 
         @thread = Thread.new do
+          Thread.current.abort_on_exception = true
+          Thread.current.report_on_exception = true if Thread.current.respond_to?(:report_on_exception=)
+
           while message = @ws.messages.pop
             if message.key?("method")
               @subscriber.async.call(message)

--- a/lib/ferrum/browser/web_socket.rb
+++ b/lib/ferrum/browser/web_socket.rb
@@ -24,6 +24,9 @@ module Ferrum
         @driver.on(:close,   &method(:on_close))
 
         @thread = Thread.new do
+          Thread.current.abort_on_exception = true
+          Thread.current.report_on_exception = true if Thread.current.respond_to?(:report_on_exception=)
+
           begin
             while data = @sock.readpartial(512)
               @driver.parse(data)


### PR DESCRIPTION
There might be code that's relying on the default behaviour of threads,
that an exception in threads won't propagate to the main thread. So it's
safer that Ferrum changes this behaviour only for threads it creates.