### PR TITLE
Fix a (presumable) typo around PDF printing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Saves PDF on a disk or returns it as base64.
 
 ```ruby
 browser.goto("https://google.com/")
-# Save on the disk in PNG
+# Save to disk as a PDF
 browser.pdf(path: "google.pdf", paper_width: 1.0, paper_height: 1.0) # => 14983
 ```
 


### PR DESCRIPTION
The functionality saves a PDF to disk, but the comment suggests it would save a PNG.