### PR TITLE
Add a method to get URL fragment from request

### DIFF
--- a/lib/ferrum/network/request.rb
+++ b/lib/ferrum/network/request.rb
@@ -30,6 +30,10 @@ module Ferrum
         @request["url"]
       end
 
+      def url_fragment
+        @request["urlFragment"]
+      end
+
       def method
         @request["method"]
       end


### PR DESCRIPTION
Thank you for the nice gem!

For example, in Implicit Flow in OpenID Connect, response parameters are returned in the redirection URL fragment value. ([Spec](https://openid.net/specs/openid-connect-core-1_0.html#ImplicitCallback))  
In this case it's helpful if there is a method to get URL fragment from `Ferrum::Network::Request`.

```ruby
browser = Ferrum::Browser.new
browser.goto('https://httpbin.org/get#foo=bar')

request = browser.network.request

# without url_fragment method
url_fragment = request.instance_variable_get(:@request)['urlFragment']
puts url_fragment
# => #foo=bar

# with url_fragment method
puts request.url_fragment
# => #foo=bar
```
