### PR TITLE
Remove deprecated `Network.continueInterceptedRequest` calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ browser.network.intercept
 browser.on(:request) do |request|
   if request.match?(/bla-bla/)
     request.abort
+  elsif request.match?(/lorem/)
+    request.respond(body: "Lorem ipsum")
   else
     request.continue
   end

--- a/lib/ferrum/network/auth_request.rb
+++ b/lib/ferrum/network/auth_request.rb
@@ -2,7 +2,7 @@
 
 module Ferrum
   class Network
-    class InterceptedRequest
+    class AuthRequest
       attr_accessor :request_id, :frame_id, :resource_type
 
       def initialize(page, params)
@@ -17,13 +17,17 @@ module Ferrum
         @params["isNavigationRequest"]
       end
 
+      def auth_challenge?(source)
+        @params.dig("authChallenge", "source")&.downcase&.to_s == source.to_s
+      end
+
       def match?(regexp)
         !!url.match(regexp)
       end
 
       def continue(**options)
         options = options.merge(requestId: request_id)
-        @page.command("Fetch.continueRequest", **options)
+        @page.command("Fetch.continueWithAuth", **options)
       end
 
       def abort

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -124,8 +124,13 @@ module Ferrum
           block.call(dialog, index, total)
         end
       when :request
-        @client.on("Network.requestIntercepted") do |params, index, total|
+        @client.on("Fetch.requestPaused") do |params, index, total|
           request = Network::InterceptedRequest.new(self, params)
+          block.call(request, index, total)
+        end
+      when :auth
+        @client.on("Fetch.authRequired") do |params, index, total|
+          request = Network::AuthRequest.new(self, params)
           block.call(request, index, total)
         end
       else

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -286,6 +286,18 @@ module Ferrum
         frame = browser.at_xpath("//iframe[@name = 'unwantedframe']").frame
         expect(frame.body).to include("We shouldn't see this.")
       end
+
+      it "supports custom responses" do
+        browser.network.intercept
+        browser.on(:request) do |request|
+          request.respond(body: "<h1>content</h1>")
+        end
+
+        browser.goto("/ferrum/non_existing")
+
+        expect(browser.network.status).to eq(200)
+        expect(browser.body).to include("content")
+      end
     end
   end
 end


### PR DESCRIPTION
Switch from deprecated `Network.continueInterceptedRequest` to `Fetch.continueRequest`.
This resulted in a small API change. Auth callbacks are now separated from regular request callbacks and registration for them are now handled separately.

Additionally I added the ability for custom request fulfilment but I'm not 100% sure about the API design.