### PR TITLE
Issue#18 full screenshots dont show page content

### DIFF
--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -87,11 +87,11 @@ module Ferrum
 
       if fullscreen
         @browser.command("Browser.setWindowBounds", windowId: @window_id, bounds: { windowState: "fullscreen" })
-        override_device_metrics_sizes!(*document_size)
+        override_device_metrics_sizes(*document_size)
       else
         @browser.command("Browser.setWindowBounds", windowId: @window_id, bounds: { windowState: "normal" })
         @browser.command("Browser.setWindowBounds", windowId: @window_id, bounds: { width: width, height: height, windowState: "normal" })
-        override_device_metrics_sizes!(width, height)
+        override_device_metrics_sizes(width, height)
       end
     end
 
@@ -232,7 +232,7 @@ module Ferrum
       @document_id = command("DOM.getDocument", depth: 0).dig("root", "nodeId")
     end
 
-    def override_device_metrics_sizes!(width, height)
+    def override_device_metrics_sizes(width, height)
       options = { width: width, height: height, deviceScaleFactor: 1, mobile: false, fitWindow: false }
       command("Emulation.setDeviceMetricsOverride", options)
     end

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -87,10 +87,11 @@ module Ferrum
 
       if fullscreen
         @browser.command("Browser.setWindowBounds", windowId: @window_id, bounds: { windowState: "fullscreen" })
+        override_device_metrics_sizes!(*document_size)
       else
         @browser.command("Browser.setWindowBounds", windowId: @window_id, bounds: { windowState: "normal" })
         @browser.command("Browser.setWindowBounds", windowId: @window_id, bounds: { width: width, height: height, windowState: "normal" })
-        command("Emulation.setDeviceMetricsOverride", width: width, height: height, deviceScaleFactor: 1, mobile: false)
+        override_device_metrics_sizes!(width, height)
       end
     end
 
@@ -229,6 +230,11 @@ module Ferrum
 
     def get_document_id
       @document_id = command("DOM.getDocument", depth: 0).dig("root", "nodeId")
+    end
+
+    def override_device_metrics_sizes!(width, height)
+      options = { width: width, height: height, deviceScaleFactor: 1, mobile: false, fitWindow: false }
+      command("Emulation.setDeviceMetricsOverride", options)
     end
   end
 end

--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -21,7 +21,7 @@ module Ferrum
       def screenshot(**opts)
         path, encoding = common_options(**opts)
         options = screenshot_options(path, **opts)
-        data = fetch_screenshot_capture(options, fullscreen: opts[:full])
+        data = screenshot_capture_data(options, **opts)
         return data if encoding == :base64
         save_file(path, data)
       end
@@ -129,15 +129,27 @@ module Ferrum
         { x: rect[0], y: rect[1], width: rect[2], height: rect[3] }
       end
 
-      def fetch_screenshot_capture(options, fullscreen: false)
-        current_viewport_size_values = viewport_size.dup
-        resize(fullscreen: true) if fullscreen
-        data = command("Page.captureScreenshot", **options).fetch("data")
-        if fullscreen
-          width, height = current_viewport_size_values
-          resize(width: width, height: height)
-        end
+      def screenshot_capture_data(options, **opts)
+        begin
+          if opts[:full]
+            fullscreen_screenshot_capture(**options)
+          else
+            screenshot_capture(**options)
+          end
+        end.fetch("data")
+      end
+
+      def fullscreen_screenshot_capture(**options)
+        current_viewport_sizes = viewport_size.dup
+        resize(fullscreen: true)
+        data = screenshot_capture(**options)
+        width, height = current_viewport_sizes
+        resize(width: width, height: height)
         data
+      end
+
+      def screenshot_capture(**options)
+        command("Page.captureScreenshot", **options)
       end
     end
   end

--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -21,7 +21,7 @@ module Ferrum
       def screenshot(**opts)
         path, encoding = common_options(**opts)
         options = screenshot_options(path, **opts)
-        data = screenshot_capture_data(options, **opts)
+        data = screenshot_capture_data(options, fullscreen: opts[:full])
         return data if encoding == :base64
         save_file(path, data)
       end
@@ -129,9 +129,9 @@ module Ferrum
         { x: rect[0], y: rect[1], width: rect[2], height: rect[3] }
       end
 
-      def screenshot_capture_data(options, **opts)
+      def screenshot_capture_data(options, fullscreen:)
         begin
-          if opts[:full]
+          if fullscreen
             fullscreen_screenshot_capture(**options)
           else
             screenshot_capture(**options)
@@ -142,10 +142,10 @@ module Ferrum
       def fullscreen_screenshot_capture(**options)
         current_viewport_sizes = viewport_size.dup
         resize(fullscreen: true)
-        data = screenshot_capture(**options)
+        screenshot_capture(**options)
+      ensure
         width, height = current_viewport_sizes
         resize(width: width, height: height)
-        data
       end
 
       def screenshot_capture(**options)

--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -137,24 +137,24 @@ module Ferrum
       def screenshot_capture_data(options, fullscreen:)
         begin
           if fullscreen
-            fullscreen_screenshot_capture(**options)
+            fullscreen_screenshot_capture(options)
           else
-            screenshot_capture(**options)
+            screenshot_capture(options)
           end
         end.fetch("data")
       end
 
-      def fullscreen_screenshot_capture(**options)
+      def fullscreen_screenshot_capture(options)
         current_viewport_sizes = viewport_size.dup
         resize(fullscreen: true)
-        screenshot_capture(**options)
+        screenshot_capture(options)
       ensure
         width, height = current_viewport_sizes
         resize(width: width, height: height)
       end
 
-      def screenshot_capture(**options)
-        command("Page.captureScreenshot", **options)
+      def screenshot_capture(options)
+        command("Page.captureScreenshot", options)
       end
     end
   end

--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -21,7 +21,7 @@ module Ferrum
       def screenshot(**opts)
         path, encoding = common_options(**opts)
         options = screenshot_options(path, **opts)
-        data = command("Page.captureScreenshot", **options).fetch("data")
+        data = fetch_screenshot_capture(options, fullscreen: opts[:full])
         return data if encoding == :base64
         save_file(path, data)
       end
@@ -127,6 +127,17 @@ module Ferrum
         ), timeout)
 
         { x: rect[0], y: rect[1], width: rect[2], height: rect[3] }
+      end
+
+      def fetch_screenshot_capture(options, fullscreen: false)
+        current_viewport_size_values = viewport_size.dup
+        resize(fullscreen: true) if fullscreen
+        data = command("Page.captureScreenshot", **options).fetch("data")
+        if fullscreen
+          width, height = current_viewport_size_values
+          resize(width: width, height: height)
+        end
+        data
       end
     end
   end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -68,6 +68,13 @@ module Ferrum
       expect(browser.viewport_size).to eq([200, 400])
     end
 
+    it "allows the viewport to be resized by fullscreen" do
+      browser.goto("/ferrum/custom_html_size")
+      expect(browser.viewport_size).to eq([1024, 768])
+      browser.resize(fullscreen: true)
+      expect(browser.viewport_size).to eq([1280, 1024])
+    end
+
     it "allows the page to be scrolled" do
       browser.goto("/ferrum/long_page")
       browser.resize(width: 10, height: 10)

--- a/spec/screenshot_spec.rb
+++ b/spec/screenshot_spec.rb
@@ -108,6 +108,26 @@ module Ferrum
           expect(File.exist?(file)).to be true
         end
 
+        context "fullscreen" do
+          it "supports screenshotting of fullscreen" do
+            browser.goto "/ferrum/custom_html_size"
+            expect(browser.viewport_size).to eq([1024, 768])
+            browser.screenshot(path: file, full: true)
+            File.open(file, "rb") do |f|
+              expect(ImageSize.new(f.read).size).to eq([1280, 1024])
+            end
+            expect(browser.viewport_size).to eq([1024, 768])
+          end
+
+          it "does not change the current document sizes" do
+            browser.goto
+            browser.resize width: 800, height: 200
+            browser.screenshot(path: file, full: true)
+            expect(File.exist?(file)).to be true
+            expect(browser.viewport_size).to eq([800, 200])
+          end
+        end
+
         it "supports screenshotting the page to file without extension when format is specified" do
           begin
             file = PROJECT_ROOT + "/spec/tmp/screenshot"

--- a/spec/screenshot_spec.rb
+++ b/spec/screenshot_spec.rb
@@ -126,6 +126,20 @@ module Ferrum
             expect(File.exist?(file)).to be true
             expect(browser.viewport_size).to eq([800, 200])
           end
+
+          it "returns correct document sizes even exception while fullscreen capturing" do
+            browser.goto "/ferrum/custom_html_size"
+            browser.resize width: 100, height: 100
+            allow(browser.page).to receive(:command).and_call_original
+            fullscreen_options = { format: "png", clip: { x: 0, y: 0, width: 1280, height: 1024, scale: 1.0 }}
+            expect(browser.page)
+              .to receive(:command)
+              .with("Page.captureScreenshot", fullscreen_options)
+              .and_raise(StandardError)
+            expect { browser.screenshot(path: file, full: true) }.to raise_exception(StandardError)
+            expect(File.exist?(file)).not_to be
+            expect(browser.viewport_size).to eq([100, 100])
+          end
         end
 
         it "supports screenshotting the page to file without extension when format is specified" do

--- a/spec/support/views/custom_html_size.erb
+++ b/spec/support/views/custom_html_size.erb
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>custom_size</title>
+  <style>
+    html {
+      width: 1280px;
+      height: 1024px;
+    }
+  </style>
+</head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Closes: #18 

According to [this WiKi](https://github.com/cyrus-and/chrome-remote-interface/wiki/Take-page-screenshot) we should override the metrics before try of taking a full-page screenshot and also better to revert them after the capture action to not confuse the data for the current instance of `@client`.
