### PR TITLE
Use default user-agent when overriding special headers.

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -25,6 +25,7 @@ module Ferrum
                 evaluate evaluate_on evaluate_async execute
                 add_script_tag add_style_tag
                 on] => :page
+    delegate %i[default_user_agent] => :process
 
     attr_reader :client, :process, :contexts, :logger, :js_errors,
                 :slowmo, :base_url, :options, :window_size

--- a/lib/ferrum/headers.rb
+++ b/lib/ferrum/headers.rb
@@ -40,7 +40,7 @@ module Ferrum
 
     def set_overrides(user_agent: nil, accept_language: nil, platform: nil)
       options = Hash.new
-      options[:userAgent] = user_agent if user_agent
+      options[:userAgent] = user_agent || @page.browser.default_user_agent
       options[:acceptLanguage] = accept_language if accept_language
       options[:platform] if platform
 

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -48,6 +48,13 @@ module Ferrum
         expect(browser.body).to include("APPENDED: true")
       end
 
+      it "sets accept-language even if user-agent is not provided" do
+        browser.headers.add("Accept-Language" => "esperanto")
+        browser.goto("/ferrum/headers")
+        expect(browser.body).to include("USER_AGENT: #{browser.default_user_agent}")
+        expect(browser.body).to match(/ACCEPT_LANGUAGE: esperanto/)
+      end
+
       it "sets headers on the initial request for referer only" do
         browser.headers.set("PermanentA" => "a")
         browser.headers.add("PermanentB" => "b")


### PR DESCRIPTION
Accept-Language is overridden through [`setUserAgentOverride` method in Network domain](https://chromedevtools.github.io/devtools-protocol/tot/Network#method-setUserAgentOverride), which declares User-Agent to be a required parameter. As we don't always care to set User-Agent
at the same time as we set Accept-Language, we should store chrome own user agent as reported on `/json/version` endpoint, and reuse it if needed.

### Issue reproduction path

```
require 'ferrum'
browser = Ferrum::Browser.new
browser.headers.add({"Accept-Language"=>"en"}) # => Ferrum::BrowserError: Invalid parameters
```

### Expected outcome, as implemented

Provided headers are added.
User-Agent defaults to chrome default one, unless otherwise specified.

### Actual outcome, as exhibited by master

`Ferrum::BrowserError: Invalid parameters` error is raised