### PR TITLE
Get rid of deprecated events

### DIFF
--- a/lib/ferrum.rb
+++ b/lib/ferrum.rb
@@ -10,8 +10,14 @@ module Ferrum
   class NotImplementedError < Error; end
 
   class StatusError < Error
-    def initialize(url)
-      super("Request to #{url} failed to reach server, check DNS and/or server status")
+    def initialize(url, pendings = [])
+      message = if pendings.empty?
+                  "Request to #{url} failed to reach server, check DNS and/or server status"
+                else
+                  "Request to #{url} reached server, but there are still pending connections: #{pendings.join(', ')}"
+                end
+
+      super(message)
     end
   end
 

--- a/lib/ferrum/frame.rb
+++ b/lib/ferrum/frame.rb
@@ -18,8 +18,6 @@ module Ferrum
     # Can be one of:
     # * started_loading
     # * navigated
-    # * scheduled_navigation
-    # * cleared_scheduled_navigation
     # * stopped_loading
     def state=(value)
       @state = value

--- a/lib/ferrum/network/exchange.rb
+++ b/lib/ferrum/network/exchange.rb
@@ -30,6 +30,10 @@ module Ferrum
         blocked? || response || error
       end
 
+      def pending?
+        !finished?
+      end
+
       def to_a
         [request, response, error]
       end

--- a/lib/ferrum/page/frames.rb
+++ b/lib/ferrum/page/frames.rb
@@ -40,18 +40,6 @@ module Ferrum
           frame.name = name unless name.to_s.empty?
         end
 
-        on("Page.frameScheduledNavigation") do |params|
-          frame = @frames[params["frameId"]]
-          frame.state = :scheduled_navigation
-          @event.reset
-        end
-
-        on("Page.frameClearedScheduledNavigation") do |params|
-          frame = @frames[params["frameId"]]
-          frame.state = :cleared_scheduled_navigation
-          @event.set if idling?
-        end
-
         on("Page.frameStoppedLoading") do |params|
           # `DOM.performSearch` doesn't work without getting #document node first.
           # It returns node with nodeId 1 and nodeType 9 from which descend the

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -179,9 +179,10 @@ module Ferrum
         expect(browser.network.status).to eq(500)
       end
 
-      it "determines properly status when user goes through a few pages", skip: true do
+      it "determines properly status when user goes through a few pages" do
         browser.goto("/ferrum/with_different_resources")
 
+        browser.at_xpath("//a[text() = 'Go to 200']").click
         browser.at_xpath("//a[text() = 'Go to 201']").click
         browser.at_xpath("//a[text() = 'Do redirect']").click
         browser.at_xpath("//a[text() = 'Go to 402']").click

--- a/spec/support/views/with_different_resources.erb
+++ b/spec/support/views/with_different_resources.erb
@@ -5,9 +5,10 @@
   </head>
 
   <body>
-    <img src="unexist.png">
+    <img src="/ferrum/unexist.png">
 
     <a href="/ferrum/redirect">Do redirect</a>
+    <a href="/ferrum/status/200">Go to 200</a>
     <a href="/ferrum/status/201">Go to 201</a>
     <a href="/ferrum/status/402">Go to 402</a>
     <a href="/ferrum/status/500">Go to 500</a>


### PR DESCRIPTION
- Get rid of deprecated events `Page.frameScheduledNavigation` and `Page.frameClearedScheduledNavigation`
- Remove `Page.domContentEventFired` event as `frameStoppedLoading` occures eventually
but it takes Chrome 20s to realize that, I'm not sure if there's a setting for that and if it's a real bug.
- Fix `goto` waiting twice the same time as first waiting should be as short as possible
- Show pending requests if timeout exceeded