### PR TITLE
Allow users to specify max websocket receive size

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Ferrum::Browser.new(options)
       browser process will not be spawned.
   * `:process_timeout` (Integer) - How long to wait for the Chrome process to
       respond on startup
+  * `:ws_max_receive_size` (Integer) - How big messages to accept from Chrome
+      over the web socket, in bytes. Defaults to 64MB. Incoming messages larger
+      than this will cause a `Ferrum::DeadBrowserError`.
 
 
 #### The API below is for master branch and a subject to change before 1.0

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -28,7 +28,7 @@ module Ferrum
     delegate %i[default_user_agent] => :process
 
     attr_reader :client, :process, :contexts, :logger, :js_errors,
-                :slowmo, :base_url, :options, :window_size
+                :slowmo, :base_url, :options, :window_size, :ws_max_receive_size
     attr_writer :timeout
 
     def initialize(options = nil)
@@ -39,7 +39,7 @@ module Ferrum
       @original_window_size = @window_size
 
       @options = Hash(options.merge(window_size: @window_size))
-      @logger, @timeout = @options.values_at(:logger, :timeout)
+      @logger, @timeout, @ws_max_receive_size = @options.values_at(:logger, :timeout, :ws_max_receive_size)
       @js_errors = @options.fetch(:js_errors, false)
       @slowmo = @options[:slowmo].to_i
 

--- a/lib/ferrum/browser/client.rb
+++ b/lib/ferrum/browser/client.rb
@@ -14,7 +14,7 @@ module Ferrum
         @pendings = Concurrent::Hash.new
         @browser = browser
         @slowmo = @browser.slowmo if allow_slowmo && @browser.slowmo > 0
-        @ws = WebSocket.new(ws_url, @browser.logger)
+        @ws = WebSocket.new(ws_url, @browser.ws_max_receive_size, @browser.logger)
         @subscriber, @interruptor = Subscriber.build(2)
 
         @thread = Thread.new do

--- a/lib/ferrum/browser/web_socket.rb
+++ b/lib/ferrum/browser/web_socket.rb
@@ -11,12 +11,13 @@ module Ferrum
 
       attr_reader :url, :messages
 
-      def initialize(url, logger)
+      def initialize(url, max_receive_size, logger)
         @url      = url
         @logger   = logger
         uri       = URI.parse(@url)
         @sock     = TCPSocket.new(uri.host, uri.port)
-        @driver   = ::WebSocket::Driver.client(self)
+        max_receive_size ||= ::WebSocket::Driver::MAX_LENGTH
+        @driver   = ::WebSocket::Driver.client(self, max_length: max_receive_size)
         @messages = Queue.new
 
         @driver.on(:open,    &method(:on_open))


### PR DESCRIPTION
`::WebSocket::Driver` has a [limit](https://github.com/faye/websocket-driver-ruby/blob/0.7.0/lib/websocket/driver/hybi.rb#L327) on the amount of data it is willing to receive from the remote side. This limit is configurable via the `:max_length` option and defaults to 64MB.

One way to hit this limit is to print a large HTML to PDF (> 48 MB) via `browser.pdf`. Doing so will cause `::WebSocket::Driver` to close the socket with error code 1009 and error message "WebSocket frame length too large", which in turn causes `Ferrum` to raise a `Ferrum::DeadBrowserError`.

This PR adds a way to set a custom `:max_length` value to the web socket. We need this option because occasionally we may have to print HTMLs with large images in it that exceed 48 MB.