### PR TITLE
Raise a specific error when browser takes too long to start

### DIFF
--- a/lib/ferrum.rb
+++ b/lib/ferrum.rb
@@ -30,6 +30,12 @@ module Ferrum
     end
   end
 
+  class ProcessTimeoutError < Error
+    def initialize(message = "Timed out waiting for browser process to start")
+      super
+    end
+  end
+
   class DeadBrowserError < Error
     def initialize(message = "Browser is dead or given window is closed")
       super

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -134,7 +134,7 @@ module Ferrum
 
         unless ws_url
           @logger.puts output if @logger
-          raise "Browser process did not produce websocket url within #{timeout} seconds"
+          raise ProcessTimeoutError, "Browser did not produce websocket url within #{timeout} seconds"
         end
       end
 


### PR DESCRIPTION
A generic `RuntimeError` was raised when the browser failed to respond with a WebSocket URL on time. This makes it difficult for client code to distinguish and inconvenient to handle this particular error.

We do need to handle it in our code, since we do encounter it – very, very rarely, but it does occur occasionally. To that end, this PR adds a new error type for timeout errors in `Ferrum::Browser::Process` and raises it when the browser fails to respond with a WebSocket URL on time.