### PR TITLE
Use scrollHeight & scrollWidth for fullscreen screenshot

### DIFF
--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -48,8 +48,8 @@ module Ferrum
 
       def document_size
         evaluate <<~JS
-          [document.documentElement.offsetWidth,
-           document.documentElement.offsetHeight]
+          [document.documentElement.scrollWidth,
+           document.documentElement.scrollHeight]
         JS
       end
 

--- a/spec/support/views/custom_html_size.erb
+++ b/spec/support/views/custom_html_size.erb
@@ -1,13 +1,19 @@
 <html>
-<head>
-  <title>custom_size</title>
-  <style>
-    html {
-      width: 1280px;
-      height: 1024px;
-    }
-  </style>
-</head>
+  <head>
+    <title>custom_size</title>
+    <style>
+      html {
+        width: 100%;
+        height: 100%;
+      }
+
+      .spacer {
+        width:  1272px; /* using scrollWidth  adds 8px */
+        height: 1008px; /* using scrollHeight adds 16px */
+      }
+    </style>
+  </head>
   <body>
+    <div class="spacer"></div>
   </body>
 </html>


### PR DESCRIPTION
If the `html` tag has the `height` or `width` set to `100%`, `document.documentElement.offsetHeight` (`offsetWidth`) as well as `document.documentElement.clientHeight` (`clientWdith`) return the
height / width of the *viewport*.

https://github.com/coffeejunk/ferrum/blob/6906d98f48042a21c49ccccf3cf15c89541b0bc0/spec/support/views/custom_html_size.erb#L1-L19

![Screenshot from 2020-02-21 16-41-39](https://user-images.githubusercontent.com/205556/75048643-1ecafa80-54c9-11ea-932f-60ca9b1c4cd5.png)

Using `document.documentElement.scrollHeight` (`scrollWidth`) fixes this behavior as it returns the full height/width of the rendered page.

> The scrollHeight value is equal to the minimum height the element
> would require in order to fit all the content in the viewport without
> using a vertical scrollbar.
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight

> The scrollWidth value is equal to the minimum width the element would
> require in order to fit all the content in the viewport without using
> a horizontal scrollbar.
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth

Fixes #49